### PR TITLE
[fix] 🔨 하나지갑 관련 api 수정

### DIFF
--- a/src/main/java/com/example/lifeonhana/controller/WalletController.java
+++ b/src/main/java/com/example/lifeonhana/controller/WalletController.java
@@ -2,11 +2,11 @@ package com.example.lifeonhana.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,9 +40,9 @@ public class WalletController {
 		@ApiResponse(responseCode = "404", description = "하나지갑 정보를 등록할 수 없습니다.")
 	})
 	@SecurityRequirement(name = "bearerAuth")
-	public ResponseEntity<ApiResult> createWallet(@RequestHeader ("Authorization") String token,
+	public ResponseEntity<ApiResult> createWallet(@AuthenticationPrincipal String authId,
 		@RequestBody WalletDTO wallet) {
-		WalletDTO walletDTO = walletService.creatWallet(wallet, token);
+		WalletDTO walletDTO = walletService.creatWallet(wallet, authId);
 		return ResponseEntity.ok(new ApiResult(200, HttpStatus.OK, "하나지갑 정보 등록 성공", walletDTO));
 	}
 
@@ -54,8 +54,8 @@ public class WalletController {
 		@ApiResponse(responseCode = "404", description = "하나지갑 정보를 찾을 수 없습니다.")
 	})
 	@SecurityRequirement(name = "bearerAuth")
-	public ResponseEntity<ApiResult> getWallet(@RequestHeader("Authorization") String token) {
-		WalletDTO wallet = walletService.getUserWallet(token);
+	public ResponseEntity<ApiResult> getWallet(@AuthenticationPrincipal String authId) {
+		WalletDTO wallet = walletService.getUserWallet(authId);
 		return ResponseEntity.ok(new ApiResult(200, HttpStatus.OK, "하나지갑 정보 조회 성공", wallet));
 	}
 
@@ -67,8 +67,8 @@ public class WalletController {
 		@ApiResponse(responseCode = "404", description = "하나지갑 정보를 찾을 수 없습니다.")
 	})
 	@SecurityRequirement(name = "bearerAuth")
-	public ResponseEntity<ApiResult> putWallet(@RequestHeader("Authorization") String token, @RequestBody WalletDTO wallet) {
-		WalletDTO walletDTO = walletService.updateWallet(wallet, token);
+	public ResponseEntity<ApiResult> putWallet(@AuthenticationPrincipal String authId, @RequestBody WalletDTO wallet) {
+		WalletDTO walletDTO = walletService.updateWallet(wallet, authId);
 		return ResponseEntity.ok(new ApiResult(HttpStatus.OK.value(), HttpStatus.OK, "하나지갑 정보 수정 성공", walletDTO));
 	}
 

--- a/src/main/java/com/example/lifeonhana/controller/WalletController.java
+++ b/src/main/java/com/example/lifeonhana/controller/WalletController.java
@@ -11,7 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.lifeonhana.ApiResult;
-import com.example.lifeonhana.dto.WalletDTO;
+import com.example.lifeonhana.dto.request.WalletRequestDTO;
+import com.example.lifeonhana.dto.response.WalletResponseDTO;
 import com.example.lifeonhana.service.WalletService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,8 +42,8 @@ public class WalletController {
 	})
 	@SecurityRequirement(name = "bearerAuth")
 	public ResponseEntity<ApiResult> createWallet(@AuthenticationPrincipal String authId,
-		@RequestBody WalletDTO wallet) {
-		WalletDTO walletDTO = walletService.creatWallet(wallet, authId);
+		@RequestBody WalletRequestDTO wallet) {
+		WalletResponseDTO walletDTO = walletService.creatWallet(wallet, authId);
 		return ResponseEntity.ok(new ApiResult(200, HttpStatus.OK, "하나지갑 정보 등록 성공", walletDTO));
 	}
 
@@ -55,7 +56,7 @@ public class WalletController {
 	})
 	@SecurityRequirement(name = "bearerAuth")
 	public ResponseEntity<ApiResult> getWallet(@AuthenticationPrincipal String authId) {
-		WalletDTO wallet = walletService.getUserWallet(authId);
+		WalletResponseDTO wallet = walletService.getUserWallet(authId);
 		return ResponseEntity.ok(new ApiResult(200, HttpStatus.OK, "하나지갑 정보 조회 성공", wallet));
 	}
 
@@ -67,8 +68,9 @@ public class WalletController {
 		@ApiResponse(responseCode = "404", description = "하나지갑 정보를 찾을 수 없습니다.")
 	})
 	@SecurityRequirement(name = "bearerAuth")
-	public ResponseEntity<ApiResult> putWallet(@AuthenticationPrincipal String authId, @RequestBody WalletDTO wallet) {
-		WalletDTO walletDTO = walletService.updateWallet(wallet, authId);
+	public ResponseEntity<ApiResult> putWallet(@AuthenticationPrincipal String authId,
+		@RequestBody WalletRequestDTO wallet) {
+		WalletResponseDTO walletDTO = walletService.updateWallet(wallet, authId);
 		return ResponseEntity.ok(new ApiResult(HttpStatus.OK.value(), HttpStatus.OK, "하나지갑 정보 수정 성공", walletDTO));
 	}
 

--- a/src/main/java/com/example/lifeonhana/dto/WalletDTO.java
+++ b/src/main/java/com/example/lifeonhana/dto/WalletDTO.java
@@ -1,25 +1,10 @@
 package com.example.lifeonhana.dto;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-
-@Data
-@Getter
-@Setter
-@Builder
-public class WalletDTO {
-	/*
-	* walletId 급여정보id
-	* walletAmount 급여금액
-	* paymentDay 급여일
-	* startDate 시작일 (yyyy-mm)
-	* endDate 종료일 (yyyy-mm)
-	* */
-	long walletId;
-	long walletAmount;
-	String paymentDay;
-	String startDate;
-	String endDate;
+public record WalletDTO (
+	long walletId,
+	long walletAmount,
+	String paymentDay,
+	String startDate,
+	String endDate
+) {
 }

--- a/src/main/java/com/example/lifeonhana/dto/request/WalletRequestDTO.java
+++ b/src/main/java/com/example/lifeonhana/dto/request/WalletRequestDTO.java
@@ -1,0 +1,9 @@
+package com.example.lifeonhana.dto.request;
+
+public record WalletRequestDTO(
+	long walletAmount,
+	String paymentDay,
+	String startDate,
+	String endDate
+) {
+}

--- a/src/main/java/com/example/lifeonhana/dto/response/WalletResponseDTO.java
+++ b/src/main/java/com/example/lifeonhana/dto/response/WalletResponseDTO.java
@@ -1,6 +1,6 @@
-package com.example.lifeonhana.dto;
+package com.example.lifeonhana.dto.response;
 
-public record WalletDTO (
+public record WalletResponseDTO(
 	long walletId,
 	long walletAmount,
 	String paymentDay,

--- a/src/main/java/com/example/lifeonhana/repository/UserRepository.java
+++ b/src/main/java/com/example/lifeonhana/repository/UserRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByAuthId(String authId);
 
-	User getUserByUserId(Long userId);
+	User getUserByAuthId(String authId);
 }

--- a/src/main/java/com/example/lifeonhana/repository/WalletRepository.java
+++ b/src/main/java/com/example/lifeonhana/repository/WalletRepository.java
@@ -8,7 +8,7 @@ import com.example.lifeonhana.entity.User;
 import com.example.lifeonhana.entity.Wallet;
 
 public interface WalletRepository extends JpaRepository<Wallet, Long> {
-	Wallet findWalletIdByUserUserId(Long userId);
+	Wallet findWalletIdByUserAuthId(String authId);
 
 	@Query("SELECT CAST(COALESCE(SUM(w.walletAmount), 0) AS int) FROM Wallet w WHERE w.user = :user")
 	Integer findCurrentBalance(@Param("user") User user);

--- a/src/main/java/com/example/lifeonhana/service/WalletService.java
+++ b/src/main/java/com/example/lifeonhana/service/WalletService.java
@@ -7,7 +7,8 @@ import java.time.format.DateTimeParseException;
 
 import org.springframework.stereotype.Service;
 
-import com.example.lifeonhana.dto.WalletDTO;
+import com.example.lifeonhana.dto.request.WalletRequestDTO;
+import com.example.lifeonhana.dto.response.WalletResponseDTO;
 import com.example.lifeonhana.entity.User;
 import com.example.lifeonhana.entity.Wallet;
 import com.example.lifeonhana.global.exception.BadRequestException;
@@ -25,13 +26,13 @@ public class WalletService {
 		this.userRepository = userRepository;
 	}
 
-	public WalletDTO getUserWallet(String authId) {
+	public WalletResponseDTO getUserWallet(String authId) {
 		Wallet wallet = walletRepository.findWalletIdByUserAuthId(authId);
 		if (wallet == null) {
 			throw new NotFoundException("하나지갑이 존재하지 않습니다.");
 		}
 
-		return new WalletDTO(
+		return new WalletResponseDTO(
 			wallet.getWalletId(),
 			wallet.getWalletAmount(),
 			String.valueOf(wallet.getPaymentDay()),
@@ -40,7 +41,7 @@ public class WalletService {
 		);
 	}
 
-	public WalletDTO creatWallet(WalletDTO wallet, String authId) {
+	public WalletResponseDTO creatWallet(WalletRequestDTO wallet, String authId) {
 		User user = userRepository.getUserByAuthId(authId);
 		if (walletRepository.findWalletIdByUserAuthId(authId) != null) {
 			throw new BadRequestException("이미 하나지갑 정보가 존재합니다.");
@@ -50,7 +51,7 @@ public class WalletService {
 		return setWallet(wallet, newWallet);
 	}
 
-	public WalletDTO updateWallet(WalletDTO walletDTO, String authId) {
+	public WalletResponseDTO updateWallet(WalletRequestDTO walletDTO, String authId) {
 		Wallet wallet = walletRepository.findWalletIdByUserAuthId(authId);
 		if (wallet == null) {
 			throw new NotFoundException("하나지갑이 존재하지 않습니다.");
@@ -59,7 +60,7 @@ public class WalletService {
 
 	}
 
-	private WalletDTO setWallet(WalletDTO walletDTO, Wallet wallet) {
+	private WalletResponseDTO setWallet(WalletRequestDTO walletDTO, Wallet wallet) {
 		wallet.setWalletAmount(walletDTO.walletAmount());
 		wallet.setPaymentDay(Wallet.PaymentDay.fromValue(walletDTO.paymentDay()));
 		try {
@@ -79,7 +80,7 @@ public class WalletService {
 		}
 		walletRepository.save(wallet);
 
-		return new WalletDTO(
+		return new WalletResponseDTO(
 			wallet.getWalletId(),
 			wallet.getWalletAmount(),
 			wallet.getPaymentDay().toString(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #59 

## 📝 작업 내용
- wallet dto를 requestDTO와 responseDTO로 분리
- 요청 헤더에서 token받아오는 부분을 authId 받아오는 것으로 변경

## 🌳 작업 브랜치명
- `JSON-168--feature/wallet`

## 📍 리뷰 요구사항
- [x] Swagger 작성

## 💡 다음 작업 계획
- 상품관련 api 개발 시작
