### PR TITLE
[hotfix] 🦥 레디스 캐싱미스 처리

### DIFF
--- a/src/main/java/com/example/lifeonhana/controller/ArticleController.java
+++ b/src/main/java/com/example/lifeonhana/controller/ArticleController.java
@@ -52,10 +52,10 @@ public class ArticleController {
 		}
 	)
 	@GetMapping("/{articleId}")
-	public ResponseEntity<ApiResult> getArticleDetails(@PathVariable Long articleId) {
+	public ResponseEntity<ApiResult> getArticleDetails(@PathVariable Long articleId ,@AuthenticationPrincipal String authId) {
 		try {
 			// Service에서 기사 상세 데이터 가져오기
-			ArticleDetailResponse articleResponse = articleService.getArticleDetails(articleId);
+			ArticleDetailResponse articleResponse = articleService.getArticleDetails(articleId,authId);
 
 			// 성공 응답 생성
 			ApiResult result = ApiResult.builder()

--- a/src/main/java/com/example/lifeonhana/repository/ArticleRepository.java
+++ b/src/main/java/com/example/lifeonhana/repository/ArticleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.lifeonhana.entity.Article;
@@ -24,5 +25,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, JpaSpec
 	Slice<Article> findSliceByCategory(Article.Category category, Pageable pageable);
 
 	Slice<Article> findAllBy(Pageable pageable);
+
+	@Query("SELECT COUNT(al) FROM ArticleLike al WHERE al.id.articleId = :articleId AND al.isLike = true")
+	Integer findLikeCountByArticleId(@Param("articleId") Long articleId);
+
+	@Query("SELECT CASE WHEN COUNT(al) > 0 THEN true ELSE false END FROM ArticleLike al WHERE al.id.articleId = :articleId AND al.id.userId = :userId AND al.isLike = true")
+	Boolean isUserLikedArticle(@Param("articleId") Long articleId, @Param("userId") Long userId);
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
> 기사 상세 보기에서 기사 좋아요 여부와 좋아요 개수를 데이터베이스에서 가져오기 전에 레디스를 먼저 읽고 가져오게 했습니다. 
만약 레디스에 데이터가 없다면 데이터베이스에서 데이터를 가져와 레디스에 저장합니다.

## 🌳 작업 브랜치명
> JSON-198--hotfix

## 📍 리뷰 요구사항
- [ ] Swagger 작성
- [ ] 테스트코드 작성
- [ ] jacoco 커버리지 70%이상
## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 💡 다음 작업 계획
> 다음 작업 계획 간단히
